### PR TITLE
Fix phase2 cubie initialization when depth1=0 and add regression test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1116,7 +1116,11 @@ impl IdaContext {
 
 	fn init_phase2(&mut self, sctx: &StaticContext, stbl: &StaticTables) -> i8 {
 		self.probes += 1;
-		let mut cc = Cubie::new();
+		let mut cc = if self.depth1 == 0 {
+			self.p1_cubies[0]
+		} else {
+			Cubie::new()
+		};
 		for i in self.valid1 as usize..self.depth1 as usize {
 			Cubie::corn_mult(&self.p1_cubies[i], &sctx.movecube[self.mv[i] as usize], &mut cc);
 			Cubie::edge_mult(&self.p1_cubies[i], &sctx.movecube[self.mv[i] as usize], &mut cc);
@@ -1377,7 +1381,7 @@ lazy_static! {
 /// * `maxl` - number of moves to solve the cube, included. 21 or 20 is recommended.
 ///
 /// Facelet for the rubik's cube:
-/// ```
+/// ```text
 ///          +--------+
 ///          |U1 U2 U3|
 ///          |U4 U5 U6|

--- a/tests/issues_test.rs
+++ b/tests/issues_test.rs
@@ -1,0 +1,14 @@
+use min2phase::{apply_moves, solve};
+
+const MAX_SOL_LEN: u8 = 20;
+
+#[test]
+fn test_issue1_solve() {
+    let cube = "UDUDUDUDURLRLRLRLRFBFBFBFBFDUDUDUDUDLRLRLRLRLBFBFBFBFB".to_string();
+    let solution = solve(&cube, MAX_SOL_LEN);
+    let solved_cubie = apply_moves(&cube, &solution);
+    assert!(
+        solved_cubie == Some("UUUUUUUUURRRRRRRRRFFFFFFFFFDDDDDDDDDLLLLLLLLLBBBBBBBBB".to_string()),
+        "unexpected result: solution={solution} solved_cubie={solved_cubie:?}"
+    );
+}


### PR DESCRIPTION
Hey Chen,

Just wanted to say thanks for building this Rust version of min2phase - it's been super helpful for my project!

I ran into an interesting bug during testing: a particular cube state was causing my project to fail, even though it worked fine in the original Java version.

After digging in, I found the problem was in the phase 2 initialization. The cubie state wasn't getting properly set up when moving from phase 1 to phase 2.

The fix was pretty simple - I just updated the cubie state initialization in init_phase2 to use the right state when depth1 is zero.

I also added a test to cover this edge case and prevent regressions.

Thanks again for your work on this!